### PR TITLE
SL-64089: Escape multusharding request for `#delete_all` 

### DIFF
--- a/.github/workflows/active-record-multi-tenant-tests.yml
+++ b/.github/workflows/active-record-multi-tenant-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Active Record Multi-Tenant Tests
 
 on:
   push:
@@ -24,6 +24,9 @@ jobs:
           - active_record_6.0
           - active_record_6.1
           - active_record_7.0
+        citus_version:
+          - '10'
+          - '11'
         prepared_statements: [true, false]
         exclude:
           # activesupport-7.0.0 requires ruby version >= 2.7.0
@@ -31,10 +34,11 @@ jobs:
             gemfile: 'rails_7.0'
           - ruby: '2.6'
             gemfile: 'active_record_7.0'
-    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }} ${{ (matrix.prepared_statements && 'w/ prepared statements') || '' }}
+    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }} ${{ (matrix.prepared_statements && 'w/ prepared statements') || '' }} / Citus ${{ matrix.citus_version }}
     env:
        BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
        PREPARED_STATEMENTS: ${{ matrix.prepared_statements && '1' }}
+       CITUS_VERSION: ${{ matrix.citus_version }}
     steps:
       - uses: actions/checkout@v2
       - run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,25 +2,31 @@ version: '2.1'
 
 services:
   master:
-    image: 'citusdata/citus:7.5.1'
-    ports: ['5600:5432']
-    labels: ['com.citusdata.role=Master']
-    volumes: ['/var/run/postgresql']
+    container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
+    image: 'citusdata/citus:${CITUS_VERSION:-11.2}'
+    ports: [ '5600:5432' ]
+    labels: [ 'com.citusdata.role=Master' ]
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    command: -c fsync=off -c full_page_writes=off
+  worker1:
+    image: 'citusdata/citus:${CITUS_VERSION:-11.2}'
+    ports: [ '5601:5432' ]
+    labels: [ 'com.citusdata.role=Worker' ]
+    depends_on: { manager: { condition: service_healthy } }
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    command: -c fsync=off -c full_page_writes=off
+  worker2:
+    image: 'citusdata/citus:${CITUS_VERSION:-11.2}'
+    ports: [ '5602:5432' ]
+    labels: [ 'com.citusdata.role=Worker' ]
+    depends_on: { manager: { condition: service_healthy } }
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    command: -c fsync=off -c full_page_writes=off
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
-    image: 'citusdata/membership-manager:0.1.0'
-    volumes: ['/var/run/docker.sock:/var/run/docker.sock']
+    image: 'citusdata/membership-manager:0.2.0'
+    volumes: [ '/var/run/docker.sock:/var/run/docker.sock' ]
     depends_on: { master: { condition: service_healthy } }
-  worker1:
-    image: 'citusdata/citus:7.5.1'
-    labels: ['com.citusdata.role=Worker']
-    depends_on: { manager: { condition: service_healthy } }
-  worker2:
-    image: 'citusdata/citus:7.5.1'
-    labels: ['com.citusdata.role=Worker']
-    depends_on: { manager: { condition: service_healthy } }
-  healthcheck:
-    image: busybox
-    depends_on:
-      worker1: { condition: service_healthy }
-      worker2: { condition: service_healthy }

--- a/lib/activerecord-multi-tenant/delete_operations.rb
+++ b/lib/activerecord-multi-tenant/delete_operations.rb
@@ -4,8 +4,8 @@ module Arel
   module ActiveRecordRelationExtension
     # Overrides the delete_all method to include tenant scoping
     def delete_all
-      # Call the original delete_all method if the current tenant is identified by an ID
-      return super if MultiTenant.current_tenant_is_id? || MultiTenant.current_tenant.nil?
+      # Call the original delete_all method if the current tenant is identified by an ID and class is nil
+      return super if MultiTenant.current_tenant_is_id? && MultiTenant.current_tenant_class.nil?
 
       tenant_key = MultiTenant.partition_key(MultiTenant.current_tenant_class)
       tenant_id = MultiTenant.current_tenant_id


### PR DESCRIPTION
JIRA: [ticket](https://salesloft.atlassian.net/browse/SL-64089)

**Description:**

Melody's workers set the MultiTenant value as [ID](https://github.com/SalesLoft/melody/blob/b090a212dd8be728ccedc671e9122d4a404d6671/lib/sidekiq/middleware/multi_tenant.rb#L21). This cause that in this case the existing condition returns `true` and returns not overwritten behaviour for the `#delete_all` operation . 

This cause the issue with multisharding query execution for `#delete_all` operation in case when method called in background job worker. The result of this issue is described in the [ticket](https://salesloft.atlassian.net/browse/SL-64089).

**What changed:**

- Change the condition of the original #delete_all operation.