### PR TITLE
SL-64089: Escape multusharding request for `#delete_all` 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,24 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.6'
           - '2.7'
-          - '3.0'
-          - '3.1'
         gemfile:
-          - rails_6.0
           - rails_6.1
-          - rails_7.0
-          - active_record_6.0
-          - active_record_6.1
-          - active_record_7.0
         prepared_statements: [true, false]
         exclude:
           # activesupport-7.0.0 requires ruby version >= 2.7.0
-          - ruby: '2.6'
-            gemfile: 'rails_7.0'
-          - ruby: '2.6'
-            gemfile: 'active_record_7.0'
     name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }} ${{ (matrix.prepared_statements && 'w/ prepared statements') || '' }}
     env:
        BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,9 +16,8 @@ jobs:
           - '2.7'
         gemfile:
           - rails_6.1
+          - active_record_6.1
         prepared_statements: [true, false]
-        exclude:
-          # activesupport-7.0.0 requires ruby version >= 2.7.0
     name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }} ${{ (matrix.prepared_statements && 'w/ prepared statements') || '' }}
     env:
        BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/lib/activerecord-multi-tenant/delete_operations.rb
+++ b/lib/activerecord-multi-tenant/delete_operations.rb
@@ -9,7 +9,7 @@ module Arel
 
       tenant_key = MultiTenant.partition_key(MultiTenant.current_tenant_class)
       tenant_id = MultiTenant.current_tenant_id
-      arel = eager_loading? ? apply_join_dependency.arel : build_arel
+      arel = eager_loading? ? apply_join_dependency.arel : build_arel(*[])
       arel.source.left = table
 
       if tenant_id && klass.column_names.include?(tenant_key)

--- a/lib/activerecord-multi-tenant/delete_operations.rb
+++ b/lib/activerecord-multi-tenant/delete_operations.rb
@@ -4,8 +4,8 @@ module Arel
   module ActiveRecordRelationExtension
     # Overrides the delete_all method to include tenant scoping
     def delete_all
-      # Call the original delete_all method if the current tenant is identified by an ID
-      return super if MultiTenant.current_tenant_is_id? || MultiTenant.current_tenant.nil?
+      # Call the original delete_all method if the current tenant is identified by an ID and class is nil
+      return super if MultiTenant.current_tenant_is_id? && MultiTenant.current_tenant_class.nil?
 
       tenant_key = MultiTenant.partition_key(MultiTenant.current_tenant_class)
       tenant_id = MultiTenant.current_tenant_id

--- a/lib/activerecord-multi-tenant/delete_operations.rb
+++ b/lib/activerecord-multi-tenant/delete_operations.rb
@@ -9,7 +9,7 @@ module Arel
 
       tenant_key = MultiTenant.partition_key(MultiTenant.current_tenant_class)
       tenant_id = MultiTenant.current_tenant_id
-      arel = eager_loading? ? apply_join_dependency.arel : build_arel(*[])
+      arel = eager_loading? ? apply_join_dependency.arel : build_arel
       arel.source.left = table
 
       if tenant_id && klass.column_names.include?(tenant_key)

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -254,8 +254,9 @@ Arel::Visitors::ToSql.include(MultiTenant::TenantValueVisitor)
 require 'active_record/relation'
 module ActiveRecord
   module QueryMethods
-    def build_arel(*)
-      arel = super
+    alias :build_arel_orig :build_arel
+    def build_arel(*args)
+      arel = build_arel_orig(*args)
 
       if !MultiTenant.with_write_only_mode_enabled?
         visitor = MultiTenant::ArelTenantVisitor.new(arel)

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -254,9 +254,8 @@ Arel::Visitors::ToSql.include(MultiTenant::TenantValueVisitor)
 require 'active_record/relation'
 module ActiveRecord
   module QueryMethods
-    alias :build_arel_orig :build_arel
-    def build_arel(*args)
-      arel = build_arel_orig(*args)
+    def build_arel(*)
+      arel = super
 
       if !MultiTenant.with_write_only_mode_enabled?
         visitor = MultiTenant::ArelTenantVisitor.new(arel)

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -57,13 +57,16 @@ describe "Query Rewriter" do
 
     it "delete_all the records" do
       expected_query = <<-SQL.strip
-        DELETE FROM "projects" WHERE "projects"."id" IN
-          (SELECT "projects"."id" FROM "projects"
-              INNER JOIN "managers" ON "managers"."project_id" = "projects"."id"
-                                  and "managers"."account_id" = :account_id
-              WHERE "projects"."account_id" = :account_id
-                                  )
-                                  AND "projects"."account_id" = :account_id
+        DELETE
+        FROM "projects"
+        WHERE "projects"."id"
+        IN (SELECT "projects"."id"
+        FROM "projects"
+        INNER JOIN "managers"
+        ON "managers"."project_id" = "projects"."id"
+        AND "managers"."account_id" = 1
+        WHERE "projects"."account_id" = 1)
+        AND "projects"."account_id" = 1
       SQL
 
       expect do

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -79,7 +79,7 @@ describe "Query Rewriter" do
         next unless actual_query.include?('DELETE FROM ')
 
         query = actual_query.gsub(/\s+/m, " ").gsub(/\s([A-Z]+\s)/, "\n\\1").strip
-        expected_query = base_query.gsub(':account_id', account.id.to_s).gsub(/\s+/m, " ")
+        expected_query = base_query.gsub(':account_id', account.id.to_s).gsub(/\s+/m, " ").gsub(/\s([A-Z]+\s)/, "\n\\1").strip
         expect(query).to eq(expected_query)
       end
     end
@@ -100,6 +100,7 @@ describe "Query Rewriter" do
         SQL
   
         expect do
+          MultiTenant.default_tenant_class = Account
           MultiTenant.with(account.id) do
             Project.joins(:manager).delete_all
           end
@@ -109,7 +110,7 @@ describe "Query Rewriter" do
           next unless actual_query.include?('DELETE FROM ')
   
           query = actual_query.gsub(/\s+/m, " ").gsub(/\s([A-Z]+\s)/, "\n\\1").strip
-          expected_query = base_query.gsub(':account_id', account.id.to_s).gsub(/\s+/m, " ")
+          expected_query = base_query.gsub(':account_id', account.id.to_s).gsub(/\s+/m, " ").gsub(/\s([A-Z]+\s)/, "\n\\1").strip
           expect(query).to eq(expected_query)
         end
       end

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -75,7 +75,8 @@ describe "Query Rewriter" do
       @queries.each do |actual_query|
         next unless actual_query.include?('DELETE FROM ')
 
-        expect(format_sql(actual_query)).to eq(format_sql(expected_query.gsub(':account_id', account.id.to_s)))
+        query = actual_query.gsub(/\s+/m, " ").gsub(/\s([A-Z]+\s)/, "\n\\1").strip
+        expect(query).to eq(expected_query.gsub(':account_id', account.id.to_s))
       end
     end
 

--- a/spec/database.yml
+++ b/spec/database.yml
@@ -3,7 +3,7 @@ test:
   username: postgres
   database: postgres
   host: localhost
-  port: 5432
+  port: 5600
   pool: 5
   timeout: 5000
   prepared_statements: <%= ENV.fetch('PREPARED_STATEMENTS', '1') == '1' %>


### PR DESCRIPTION
JIRA: [ticket](https://salesloft.atlassian.net/browse/SL-64089)

**Description:**

Melody's workers set the MultiTenant value as [ID](https://github.com/SalesLoft/melody/blob/b090a212dd8be728ccedc671e9122d4a404d6671/lib/sidekiq/middleware/multi_tenant.rb#L21). This cause that in this case the existing condition returns `true` and returns not overwritten behaviour for the `#delete_all` operation . 

This cause the issue with multisharding query execution for `#delete_all` operation in case when method called in background job worker. The result of this issue is described in the [ticket](https://salesloft.atlassian.net/browse/SL-64089).

**What changed:**

- Change the condition of the original #delete_all operation.