### PR TITLE
DEVX-452 : chore(deps): add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependabot configuration - managed by DevX GHA upgrade initiative
+# Generated: 2026-06-04
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(deps)"
+    reviewers:
+      - "clari/pde-developer-productivity"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,4 @@ updates:
       prefix: "chore(deps)"
     reviewers:
       - "clari/pde-developer-productivity"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Adds a `dependabot.yml` to enable **weekly Dependabot updates** for GitHub Actions.

### What this PR does
- Adds `.github/dependabot.yml` with `package-ecosystem: github-actions`
- Dependabot will automatically open PRs when action versions are outdated
- Runs every **Monday**, applies `dependencies` and `github-actions` labels

### Context
Part of the **org-wide GitHub Actions Upgrade Initiative** tracked by DevX.

### Next step
After merging, a follow-up SHA-pinning migration will convert tag refs to
full commit SHAs for supply-chain security.

*Generated by DevX GHA inventory scanner — 2026-06-04*